### PR TITLE
Update linkPreview.njk

### DIFF
--- a/src/site/_includes/components/linkPreview.njk
+++ b/src/site/_includes/components/linkPreview.njk
@@ -72,7 +72,18 @@
         iframe.onload = function () {
           tooltipContentHtml = ''
           tooltipContentHtml += '<div style="font-weight: bold; unicode-bidi: plaintext;">' + iframe.contentWindow.document.querySelector('h1').innerHTML + '</div>'
-          tooltipContentHtml += iframe.contentWindow.document.querySelector('.content').innerHTML
+
+          // Edit Felix.Fromm
+          // tooltipContentHtml += iframe.contentWindow.document.querySelector('.content').innerHTML
+          let contentClone = iframe.contentWindow.document.querySelector('.content').cloneNode(true);
+          let firstH1 = contentClone.querySelector('h1');
+          if (firstH1) {
+              firstH1.parentNode.removeChild(firstH1);
+          }
+          tooltipContentHtml += contentClone.innerHTML;
+
+          // Edit End
+
           tooltipContent.innerHTML = tooltipContentHtml
           linkHistories[contentURL] = tooltipContentHtml
           tooltipWrapper.style.display = 'block';


### PR DESCRIPTION
linkPreview uses the first <h1> element as title (converted from # in the md), but then uses the whole content as “preview”.

My change will remove the first <h1> (#) entry from the context so that the title is not displayed 2 times.